### PR TITLE
Optimizacion1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,6 @@
 {
 	"name": "testing-webpack-plus-react",
 	"version": "1.0.0",
-<<<<<<< HEAD
-	"lockfileVersion": 1,
-	"requires": true,
-=======
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
@@ -23,11 +19,13 @@
 				"@babel/preset-react": "^7.18.6",
 				"babel-loader": "^8.2.5",
 				"css-loader": "^6.7.1",
+				"css-minimizer-webpack-plugin": "^4.2.2",
 				"html-loader": "^4.2.0",
 				"html-webpack-plugin": "^5.5.0",
 				"sass": "^1.55.0",
 				"sass-loader": "^13.1.0",
 				"style-loader": "^3.3.1",
+				"terser-webpack-plugin": "^5.3.6",
 				"webpack": "^5.74.0",
 				"webpack-cli": "^4.10.0",
 				"webpack-dev-server": "^4.11.1"
@@ -1740,6 +1738,96 @@
 				"node": ">=10.0.0"
 			}
 		},
+		"node_modules/@jest/schemas": {
+			"version": "29.0.0",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
+			"integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+			"dev": true,
+			"dependencies": {
+				"@sinclair/typebox": "^0.24.1"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/types": {
+			"version": "29.2.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+			"integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
+			"dev": true,
+			"dependencies": {
+				"@jest/schemas": "^29.0.0",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.8",
+				"chalk": "^4.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/types/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@jest/types/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@jest/types/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@jest/types/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/@jest/types/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
@@ -1797,6 +1885,21 @@
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
 			"dev": true
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.24.48",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.48.tgz",
+			"integrity": "sha512-WPGpRNHbkOsfBDmh8QHU7a5NWzEuYNThST8x1cISvX0RpP+1+V8zjuJqNwGJkHGIlhdIIhv6qVYqXz2q5/gjAA==",
+			"dev": true
+		},
+		"node_modules/@trysound/sax": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+			"integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.13.0"
+			}
 		},
 		"node_modules/@types/body-parser": {
 			"version": "1.19.2",
@@ -1897,6 +2000,30 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/istanbul-lib-coverage": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+			"integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+			"dev": true
+		},
+		"node_modules/@types/istanbul-lib-report": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+			"integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+			"dev": true,
+			"dependencies": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"node_modules/@types/istanbul-reports": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+			"integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+			"dev": true,
+			"dependencies": {
+				"@types/istanbul-lib-report": "*"
+			}
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -1967,6 +2094,21 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@types/yargs": {
+			"version": "17.0.13",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+			"integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
+			"dev": true,
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/@types/yargs-parser": {
+			"version": "21.0.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
+			"integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
+			"dev": true
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.11.1",
@@ -2555,6 +2697,18 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/caniuse-api": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+			"integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.0.0",
+				"caniuse-lite": "^1.0.0",
+				"lodash.memoize": "^4.1.2",
+				"lodash.uniq": "^4.5.0"
+			}
+		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001419",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001419.tgz",
@@ -2640,6 +2794,12 @@
 				"node": ">=6.0"
 			}
 		},
+		"node_modules/ci-info": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
+			"integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
+			"dev": true
+		},
 		"node_modules/clean-css": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.2.0.tgz",
@@ -2679,6 +2839,12 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true
+		},
+		"node_modules/colord": {
+			"version": "2.9.3",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
 			"dev": true
 		},
 		"node_modules/colorette": {
@@ -2839,6 +3005,18 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/css-declaration-sorter": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
+			"integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
+			"dev": true,
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.9"
+			}
+		},
 		"node_modules/css-loader": {
 			"version": "6.7.1",
 			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
@@ -2880,6 +3058,118 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/css-minimizer-webpack-plugin": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-4.2.2.tgz",
+			"integrity": "sha512-s3Of/4jKfw1Hj9CxEO1E5oXhQAxlayuHO2y/ML+C6I9sQ7FdzfEV6QgMLN3vI+qFsjJGIAFLKtQK7t8BOXAIyA==",
+			"dev": true,
+			"dependencies": {
+				"cssnano": "^5.1.8",
+				"jest-worker": "^29.1.2",
+				"postcss": "^8.4.17",
+				"schema-utils": "^4.0.0",
+				"serialize-javascript": "^6.0.0",
+				"source-map": "^0.6.1"
+			},
+			"engines": {
+				"node": ">= 14.15.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@parcel/css": {
+					"optional": true
+				},
+				"@swc/css": {
+					"optional": true
+				},
+				"clean-css": {
+					"optional": true
+				},
+				"csso": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/css-minimizer-webpack-plugin/node_modules/ajv": {
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+			"integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/css-minimizer-webpack-plugin/node_modules/ajv-keywords": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3"
+			},
+			"peerDependencies": {
+				"ajv": "^8.8.2"
+			}
+		},
+		"node_modules/css-minimizer-webpack-plugin/node_modules/jest-worker": {
+			"version": "29.2.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.2.1.tgz",
+			"integrity": "sha512-ROHTZ+oj7sBrgtv46zZ84uWky71AoYi0vEV9CdEtc1FQunsoAGe5HbQmW76nI5QWdvECVPrSi1MCVUmizSavMg==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"jest-util": "^29.2.1",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/css-minimizer-webpack-plugin/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true
+		},
+		"node_modules/css-minimizer-webpack-plugin/node_modules/schema-utils": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
+			"integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+			"dev": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.9",
+				"ajv": "^8.8.0",
+				"ajv-formats": "^2.1.1",
+				"ajv-keywords": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 12.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			}
+		},
 		"node_modules/css-select": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -2894,6 +3184,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/css-tree": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+			"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+			"dev": true,
+			"dependencies": {
+				"mdn-data": "2.0.14",
+				"source-map": "^0.6.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/css-what": {
@@ -2918,6 +3221,94 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/cssnano": {
+			"version": "5.1.13",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.13.tgz",
+			"integrity": "sha512-S2SL2ekdEz6w6a2epXn4CmMKU4K3KpcyXLKfAYc9UQQqJRkD/2eLUG0vJ3Db/9OvO5GuAdgXw3pFbR6abqghDQ==",
+			"dev": true,
+			"dependencies": {
+				"cssnano-preset-default": "^5.2.12",
+				"lilconfig": "^2.0.3",
+				"yaml": "^1.10.2"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/cssnano"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/cssnano-preset-default": {
+			"version": "5.2.12",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.12.tgz",
+			"integrity": "sha512-OyCBTZi+PXgylz9HAA5kHyoYhfGcYdwFmyaJzWnzxuGRtnMw/kR6ilW9XzlzlRAtB6PLT/r+prYgkef7hngFew==",
+			"dev": true,
+			"dependencies": {
+				"css-declaration-sorter": "^6.3.0",
+				"cssnano-utils": "^3.1.0",
+				"postcss-calc": "^8.2.3",
+				"postcss-colormin": "^5.3.0",
+				"postcss-convert-values": "^5.1.2",
+				"postcss-discard-comments": "^5.1.2",
+				"postcss-discard-duplicates": "^5.1.0",
+				"postcss-discard-empty": "^5.1.1",
+				"postcss-discard-overridden": "^5.1.0",
+				"postcss-merge-longhand": "^5.1.6",
+				"postcss-merge-rules": "^5.1.2",
+				"postcss-minify-font-values": "^5.1.0",
+				"postcss-minify-gradients": "^5.1.1",
+				"postcss-minify-params": "^5.1.3",
+				"postcss-minify-selectors": "^5.2.1",
+				"postcss-normalize-charset": "^5.1.0",
+				"postcss-normalize-display-values": "^5.1.0",
+				"postcss-normalize-positions": "^5.1.1",
+				"postcss-normalize-repeat-style": "^5.1.1",
+				"postcss-normalize-string": "^5.1.0",
+				"postcss-normalize-timing-functions": "^5.1.0",
+				"postcss-normalize-unicode": "^5.1.0",
+				"postcss-normalize-url": "^5.1.0",
+				"postcss-normalize-whitespace": "^5.1.1",
+				"postcss-ordered-values": "^5.1.3",
+				"postcss-reduce-initial": "^5.1.0",
+				"postcss-reduce-transforms": "^5.1.0",
+				"postcss-svgo": "^5.1.0",
+				"postcss-unique-selectors": "^5.1.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/cssnano-utils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
+			"integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+			"dev": true,
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/csso": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+			"integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+			"dev": true,
+			"dependencies": {
+				"css-tree": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/debug": {
@@ -3505,20 +3896,6 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
-		},
-		"node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
@@ -4149,6 +4526,84 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/jest-util": {
+			"version": "29.2.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.2.1.tgz",
+			"integrity": "sha512-P5VWDj25r7kj7kl4pN2rG/RN2c1TLfYYYZYULnS/35nFDjBai+hBeo3MDrYZS7p6IoY3YHZnt2vq4L6mKnLk0g==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^29.2.1",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-util/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/jest-util/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/jest-util/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/jest-worker": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -4219,6 +4674,15 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/lilconfig": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+			"integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/loader-runner": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -4263,6 +4727,18 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+			"dev": true
+		},
+		"node_modules/lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"dev": true
+		},
+		"node_modules/lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
 			"dev": true
 		},
 		"node_modules/loose-envify": {
@@ -4311,6 +4787,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+			"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+			"dev": true
 		},
 		"node_modules/media-typer": {
 			"version": "0.3.0",
@@ -4567,6 +5049,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/normalize-url": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/npm-run-path": {
@@ -4879,6 +5373,199 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
+		"node_modules/postcss-calc": {
+			"version": "8.2.4",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
+			"integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+			"dev": true,
+			"dependencies": {
+				"postcss-selector-parser": "^6.0.9",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.2"
+			}
+		},
+		"node_modules/postcss-colormin": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
+			"integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.16.6",
+				"caniuse-api": "^3.0.0",
+				"colord": "^2.9.1",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-convert-values": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.2.tgz",
+			"integrity": "sha512-c6Hzc4GAv95B7suy4udszX9Zy4ETyMCgFPUDtWjdFTKH1SE9eFY/jEpHSwTH1QPuwxHpWslhckUQWbNRM4ho5g==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.20.3",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-discard-comments": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
+			"integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+			"dev": true,
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-discard-duplicates": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
+			"integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+			"dev": true,
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-discard-empty": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
+			"integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+			"dev": true,
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-discard-overridden": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
+			"integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+			"dev": true,
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-merge-longhand": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.6.tgz",
+			"integrity": "sha512-6C/UGF/3T5OE2CEbOuX7iNO63dnvqhGZeUnKkDeifebY0XqkkvrctYSZurpNE902LDf2yKwwPFgotnfSoPhQiw==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0",
+				"stylehacks": "^5.1.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-merge-rules": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.2.tgz",
+			"integrity": "sha512-zKMUlnw+zYCWoPN6yhPjtcEdlJaMUZ0WyVcxTAmw3lkkN/NDMRkOkiuctQEoWAOvH7twaxUUdvBWl0d4+hifRQ==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.16.6",
+				"caniuse-api": "^3.0.0",
+				"cssnano-utils": "^3.1.0",
+				"postcss-selector-parser": "^6.0.5"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-minify-font-values": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
+			"integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-minify-gradients": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.1.tgz",
+			"integrity": "sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==",
+			"dev": true,
+			"dependencies": {
+				"colord": "^2.9.1",
+				"cssnano-utils": "^3.1.0",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-minify-params": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.3.tgz",
+			"integrity": "sha512-bkzpWcjykkqIujNL+EVEPOlLYi/eZ050oImVtHU7b4lFS82jPnsCb44gvC6pxaNt38Els3jWYDHTjHKf0koTgg==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.16.6",
+				"cssnano-utils": "^3.1.0",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-minify-selectors": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
+			"integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
+			"dev": true,
+			"dependencies": {
+				"postcss-selector-parser": "^6.0.5"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
 		"node_modules/postcss-modules-extract-imports": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
@@ -4938,6 +5625,187 @@
 				"postcss": "^8.1.0"
 			}
 		},
+		"node_modules/postcss-normalize-charset": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
+			"integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+			"dev": true,
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-normalize-display-values": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
+			"integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-normalize-positions": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
+			"integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-normalize-repeat-style": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
+			"integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-normalize-string": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
+			"integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-normalize-timing-functions": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
+			"integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-normalize-unicode": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
+			"integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.16.6",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-normalize-url": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
+			"integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
+			"dev": true,
+			"dependencies": {
+				"normalize-url": "^6.0.1",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-normalize-whitespace": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.1.tgz",
+			"integrity": "sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-ordered-values": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
+			"integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
+			"dev": true,
+			"dependencies": {
+				"cssnano-utils": "^3.1.0",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-reduce-initial": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
+			"integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.16.6",
+				"caniuse-api": "^3.0.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-reduce-transforms": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
+			"integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
 		"node_modules/postcss-selector-parser": {
 			"version": "6.0.10",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
@@ -4949,6 +5817,37 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/postcss-svgo": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
+			"integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0",
+				"svgo": "^2.7.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
+		"node_modules/postcss-unique-selectors": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",
+			"integrity": "sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==",
+			"dev": true,
+			"dependencies": {
+				"postcss-selector-parser": "^6.0.5"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
 			}
 		},
 		"node_modules/postcss-value-parser": {
@@ -5699,6 +6598,13 @@
 				"wbuf": "^1.7.3"
 			}
 		},
+		"node_modules/stable": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+			"deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
+			"dev": true
+		},
 		"node_modules/statuses": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -5760,6 +6666,22 @@
 				"webpack": "^5.0.0"
 			}
 		},
+		"node_modules/stylehacks": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
+			"integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.16.6",
+				"postcss-selector-parser": "^6.0.4"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.15"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -5784,6 +6706,36 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/svgo": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+			"integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+			"dev": true,
+			"dependencies": {
+				"@trysound/sax": "0.2.0",
+				"commander": "^7.2.0",
+				"css-select": "^4.1.3",
+				"css-tree": "^1.1.3",
+				"csso": "^4.2.0",
+				"picocolors": "^1.0.0",
+				"stable": "^0.1.8"
+			},
+			"bin": {
+				"svgo": "bin/svgo"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/svgo/node_modules/commander": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10"
 			}
 		},
 		"node_modules/tapable": {
@@ -6424,9 +7376,17 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
+		},
+		"node_modules/yaml": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
+			}
 		}
 	},
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 	"dependencies": {
 		"@ampproject/remapping": {
 			"version": "2.2.0",
@@ -7608,14 +8568,78 @@
 			"integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
 			"dev": true
 		},
+		"@jest/schemas": {
+			"version": "29.0.0",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
+			"integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+			"dev": true,
+			"requires": {
+				"@sinclair/typebox": "^0.24.1"
+			}
+		},
+		"@jest/types": {
+			"version": "29.2.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.2.1.tgz",
+			"integrity": "sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==",
+			"dev": true,
+			"requires": {
+				"@jest/schemas": "^29.0.0",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.8",
+				"chalk": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"@jridgewell/gen-mapping": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -7625,31 +8649,17 @@
 		"@jridgewell/resolve-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-			"dev": true
-=======
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"@jridgewell/set-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"dev": true
-=======
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"@jridgewell/source-map": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
 			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
@@ -7658,21 +8668,12 @@
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-			"dev": true
-=======
 			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.17",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
 			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@jridgewell/resolve-uri": "3.1.0",
 				"@jridgewell/sourcemap-codec": "1.4.14"
@@ -7682,6 +8683,18 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
+			"dev": true
+		},
+		"@sinclair/typebox": {
+			"version": "0.24.48",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.48.tgz",
+			"integrity": "sha512-WPGpRNHbkOsfBDmh8QHU7a5NWzEuYNThST8x1cISvX0RpP+1+V8zjuJqNwGJkHGIlhdIIhv6qVYqXz2q5/gjAA==",
+			"dev": true
+		},
+		"@trysound/sax": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+			"integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
 			"dev": true
 		},
 		"@types/body-parser": {
@@ -7726,10 +8739,6 @@
 			"version": "8.4.6",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
 			"integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -7739,10 +8748,6 @@
 			"version": "3.7.4",
 			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
 			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
@@ -7751,12 +8756,7 @@
 		"@types/estree": {
 			"version": "0.0.51",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-			"dev": true
-=======
 			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"@types/express": {
 			"version": "4.17.14",
@@ -7796,6 +8796,30 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/istanbul-lib-coverage": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+			"integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+			"dev": true
+		},
+		"@types/istanbul-lib-report": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+			"integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"@types/istanbul-reports": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+			"integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-report": "*"
+			}
+		},
 		"@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -7810,12 +8834,7 @@
 		"@types/node": {
 			"version": "18.11.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==",
-			"dev": true
-=======
 			"integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"@types/qs": {
 			"version": "6.9.7",
@@ -7872,14 +8891,25 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/yargs": {
+			"version": "17.0.13",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
+			"integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
+			"dev": true,
+			"requires": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"@types/yargs-parser": {
+			"version": "21.0.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
+			"integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
+			"dev": true
+		},
 		"@webassemblyjs/ast": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
 			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@webassemblyjs/helper-numbers": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -7888,41 +8918,22 @@
 		"@webassemblyjs/floating-point-hex-parser": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-			"dev": true
-=======
 			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"@webassemblyjs/helper-api-error": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-			"dev": true
-=======
 			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"@webassemblyjs/helper-buffer": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-			"dev": true
-=======
 			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"@webassemblyjs/helper-numbers": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
 			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -7932,21 +8943,12 @@
 		"@webassemblyjs/helper-wasm-bytecode": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-			"dev": true
-=======
 			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"@webassemblyjs/helper-wasm-section": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
 			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -7958,10 +8960,6 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
 			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
@@ -7970,10 +8968,6 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
 			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@xtuc/long": "4.2.2"
 			}
@@ -7981,21 +8975,12 @@
 		"@webassemblyjs/utf8": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-			"dev": true
-=======
 			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"@webassemblyjs/wasm-edit": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
 			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -8011,10 +8996,6 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
 			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -8027,10 +9008,6 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
 			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -8042,10 +9019,6 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
 			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -8059,10 +9032,6 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
 			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@xtuc/long": "4.2.2"
@@ -8072,12 +9041,8 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
 			"integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-<<<<<<< HEAD
-			"dev": true
-=======
 			"dev": true,
 			"requires": {}
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"@webpack-cli/info": {
 			"version": "1.5.0",
@@ -8092,32 +9057,18 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
 			"integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-<<<<<<< HEAD
-			"dev": true
-=======
 			"dev": true,
 			"requires": {}
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-			"dev": true
-=======
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-			"dev": true
-=======
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"accepts": {
 			"version": "1.3.8",
@@ -8132,31 +9083,18 @@
 		"acorn": {
 			"version": "8.8.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-			"dev": true
-=======
 			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"acorn-import-assertions": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-<<<<<<< HEAD
-			"dev": true
-=======
 			"requires": {}
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -8194,11 +9132,7 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-<<<<<<< HEAD
-			"dev": true
-=======
 			"requires": {}
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"ansi-html-community": {
 			"version": "0.0.8",
@@ -8409,10 +9343,6 @@
 			"version": "4.21.4",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
 			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"caniuse-lite": "^1.0.30001400",
 				"electron-to-chromium": "^1.4.251",
@@ -8423,12 +9353,7 @@
 		"buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"dev": true
-=======
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"bytes": {
 			"version": "3.0.0",
@@ -8456,15 +9381,22 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"caniuse-api": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+			"integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.0.0",
+				"caniuse-lite": "^1.0.0",
+				"lodash.memoize": "^4.1.2",
+				"lodash.uniq": "^4.5.0"
+			}
+		},
 		"caniuse-lite": {
 			"version": "1.0.30001419",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001419.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw==",
-			"dev": true
-=======
 			"integrity": "sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -8513,12 +9445,13 @@
 		"chrome-trace-event": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
-			"dev": true
-=======
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
+		},
+		"ci-info": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
+			"integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
+			"dev": true
 		},
 		"clean-css": {
 			"version": "5.2.0",
@@ -8555,6 +9488,12 @@
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true
 		},
+		"colord": {
+			"version": "2.9.3",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+			"dev": true
+		},
 		"colorette": {
 			"version": "2.0.19",
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
@@ -8564,12 +9503,7 @@
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
-=======
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -8695,6 +9629,13 @@
 				"which": "^2.0.1"
 			}
 		},
+		"css-declaration-sorter": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
+			"integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
+			"dev": true,
+			"requires": {}
+		},
 		"css-loader": {
 			"version": "6.7.1",
 			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
@@ -8722,6 +9663,73 @@
 				}
 			}
 		},
+		"css-minimizer-webpack-plugin": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-4.2.2.tgz",
+			"integrity": "sha512-s3Of/4jKfw1Hj9CxEO1E5oXhQAxlayuHO2y/ML+C6I9sQ7FdzfEV6QgMLN3vI+qFsjJGIAFLKtQK7t8BOXAIyA==",
+			"dev": true,
+			"requires": {
+				"cssnano": "^5.1.8",
+				"jest-worker": "^29.1.2",
+				"postcss": "^8.4.17",
+				"schema-utils": "^4.0.0",
+				"serialize-javascript": "^6.0.0",
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "8.11.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+					"integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"json-schema-traverse": "^1.0.0",
+						"require-from-string": "^2.0.2",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"ajv-keywords": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+					"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.3"
+					}
+				},
+				"jest-worker": {
+					"version": "29.2.1",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.2.1.tgz",
+					"integrity": "sha512-ROHTZ+oj7sBrgtv46zZ84uWky71AoYi0vEV9CdEtc1FQunsoAGe5HbQmW76nI5QWdvECVPrSi1MCVUmizSavMg==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*",
+						"jest-util": "^29.2.1",
+						"merge-stream": "^2.0.0",
+						"supports-color": "^8.0.0"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true
+				},
+				"schema-utils": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
+					"integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.9",
+						"ajv": "^8.8.0",
+						"ajv-formats": "^2.1.1",
+						"ajv-keywords": "^5.0.0"
+					}
+				}
+			}
+		},
 		"css-select": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -8735,6 +9743,16 @@
 				"nth-check": "^2.0.1"
 			}
 		},
+		"css-tree": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+			"integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+			"dev": true,
+			"requires": {
+				"mdn-data": "2.0.14",
+				"source-map": "^0.6.1"
+			}
+		},
 		"css-what": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -8746,6 +9764,70 @@
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
 			"dev": true
+		},
+		"cssnano": {
+			"version": "5.1.13",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.13.tgz",
+			"integrity": "sha512-S2SL2ekdEz6w6a2epXn4CmMKU4K3KpcyXLKfAYc9UQQqJRkD/2eLUG0vJ3Db/9OvO5GuAdgXw3pFbR6abqghDQ==",
+			"dev": true,
+			"requires": {
+				"cssnano-preset-default": "^5.2.12",
+				"lilconfig": "^2.0.3",
+				"yaml": "^1.10.2"
+			}
+		},
+		"cssnano-preset-default": {
+			"version": "5.2.12",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.12.tgz",
+			"integrity": "sha512-OyCBTZi+PXgylz9HAA5kHyoYhfGcYdwFmyaJzWnzxuGRtnMw/kR6ilW9XzlzlRAtB6PLT/r+prYgkef7hngFew==",
+			"dev": true,
+			"requires": {
+				"css-declaration-sorter": "^6.3.0",
+				"cssnano-utils": "^3.1.0",
+				"postcss-calc": "^8.2.3",
+				"postcss-colormin": "^5.3.0",
+				"postcss-convert-values": "^5.1.2",
+				"postcss-discard-comments": "^5.1.2",
+				"postcss-discard-duplicates": "^5.1.0",
+				"postcss-discard-empty": "^5.1.1",
+				"postcss-discard-overridden": "^5.1.0",
+				"postcss-merge-longhand": "^5.1.6",
+				"postcss-merge-rules": "^5.1.2",
+				"postcss-minify-font-values": "^5.1.0",
+				"postcss-minify-gradients": "^5.1.1",
+				"postcss-minify-params": "^5.1.3",
+				"postcss-minify-selectors": "^5.2.1",
+				"postcss-normalize-charset": "^5.1.0",
+				"postcss-normalize-display-values": "^5.1.0",
+				"postcss-normalize-positions": "^5.1.1",
+				"postcss-normalize-repeat-style": "^5.1.1",
+				"postcss-normalize-string": "^5.1.0",
+				"postcss-normalize-timing-functions": "^5.1.0",
+				"postcss-normalize-unicode": "^5.1.0",
+				"postcss-normalize-url": "^5.1.0",
+				"postcss-normalize-whitespace": "^5.1.1",
+				"postcss-ordered-values": "^5.1.3",
+				"postcss-reduce-initial": "^5.1.0",
+				"postcss-reduce-transforms": "^5.1.0",
+				"postcss-svgo": "^5.1.0",
+				"postcss-unique-selectors": "^5.1.1"
+			}
+		},
+		"cssnano-utils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
+			"integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+			"dev": true,
+			"requires": {}
+		},
+		"csso": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+			"integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+			"dev": true,
+			"requires": {
+				"css-tree": "^1.1.2"
+			}
 		},
 		"debug": {
 			"version": "4.3.4",
@@ -8887,12 +9969,7 @@
 		"electron-to-chromium": {
 			"version": "1.4.283",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.283.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-g6RQ9zCOV+U5QVHW9OpFR7rdk/V7xfopNXnyAamdpFgCHgZ1sjI8VuR1+zG2YG/TZk+tQ8mpNkug4P8FU0fuOA==",
-			"dev": true
-=======
 			"integrity": "sha512-g6RQ9zCOV+U5QVHW9OpFR7rdk/V7xfopNXnyAamdpFgCHgZ1sjI8VuR1+zG2YG/TZk+tQ8mpNkug4P8FU0fuOA=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"emojis-list": {
 			"version": "3.0.0",
@@ -8910,10 +9987,6 @@
 			"version": "5.10.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
 			"integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"graceful-fs": "^4.2.4",
 				"tapable": "^2.2.0"
@@ -8934,22 +10007,12 @@
 		"es-module-lexer": {
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-			"dev": true
-=======
 			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"escalade": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-			"dev": true
-=======
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"escape-html": {
 			"version": "1.0.3",
@@ -8967,10 +10030,6 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
@@ -8980,10 +10039,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"estraverse": "^5.2.0"
 			},
@@ -8991,24 +10046,14 @@
 				"estraverse": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-<<<<<<< HEAD
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-=======
 					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 				}
 			}
 		},
 		"estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true
-=======
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"esutils": {
 			"version": "2.0.3",
@@ -9031,12 +10076,7 @@
 		"events": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-			"dev": true
-=======
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"execa": {
 			"version": "5.1.1",
@@ -9125,12 +10165,7 @@
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
-=======
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"fastest-levenshtein": {
 			"version": "1.0.16",
@@ -9239,13 +10274,6 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
-		"fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"optional": true
-		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -9301,12 +10329,7 @@
 		"glob-to-regexp": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"dev": true
-=======
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"globals": {
 			"version": "11.12.0",
@@ -9317,12 +10340,7 @@
 		"graceful-fs": {
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-			"dev": true
-=======
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"handle-thing": {
 			"version": "2.0.1",
@@ -9342,12 +10360,7 @@
 		"has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true
-=======
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"has-property-descriptors": {
 			"version": "1.0.0",
@@ -9577,12 +10590,8 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
 			"integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-<<<<<<< HEAD
-			"dev": true
-=======
 			"dev": true,
 			"requires": {}
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"immutable": {
 			"version": "4.1.0",
@@ -9721,14 +10730,69 @@
 			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
 			"dev": true
 		},
+		"jest-util": {
+			"version": "29.2.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.2.1.tgz",
+			"integrity": "sha512-P5VWDj25r7kj7kl4pN2rG/RN2c1TLfYYYZYULnS/35nFDjBai+hBeo3MDrYZS7p6IoY3YHZnt2vq4L6mKnLk0g==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^29.2.1",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"jest-worker": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
 			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -9749,22 +10813,12 @@
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true
-=======
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
-=======
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"json5": {
 			"version": "2.2.1",
@@ -9784,15 +10838,16 @@
 			"integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
 			"dev": true
 		},
+		"lilconfig": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+			"integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+			"dev": true
+		},
 		"loader-runner": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
-			"dev": true
-=======
 			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"loader-utils": {
 			"version": "2.0.2",
@@ -9824,6 +10879,18 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+			"dev": true
+		},
+		"lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"dev": true
+		},
+		"lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
 			"dev": true
 		},
 		"loose-envify": {
@@ -9861,6 +10928,12 @@
 				"semver": "^6.0.0"
 			}
 		},
+		"mdn-data": {
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+			"integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+			"dev": true
+		},
 		"media-typer": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -9885,12 +10958,7 @@
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-			"dev": true
-=======
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"methods": {
 			"version": "1.1.2",
@@ -9917,21 +10985,12 @@
 		"mime-db": {
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"dev": true
-=======
 			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"mime-types": {
 			"version": "2.1.35",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
 			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"mime-db": "1.52.0"
 			}
@@ -10033,12 +11092,7 @@
 		"neo-async": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"dev": true
-=======
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"no-case": {
 			"version": "3.0.4",
@@ -10059,17 +11113,18 @@
 		"node-releases": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
-			"dev": true
-=======
 			"integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
+		},
+		"normalize-url": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
 			"dev": true
 		},
 		"npm-run-path": {
@@ -10266,12 +11321,7 @@
 		"picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-			"dev": true
-=======
 			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"picomatch": {
 			"version": "2.3.1",
@@ -10299,16 +11349,134 @@
 				"source-map-js": "^1.0.2"
 			}
 		},
+		"postcss-calc": {
+			"version": "8.2.4",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
+			"integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+			"dev": true,
+			"requires": {
+				"postcss-selector-parser": "^6.0.9",
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-colormin": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
+			"integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.16.6",
+				"caniuse-api": "^3.0.0",
+				"colord": "^2.9.1",
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-convert-values": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.2.tgz",
+			"integrity": "sha512-c6Hzc4GAv95B7suy4udszX9Zy4ETyMCgFPUDtWjdFTKH1SE9eFY/jEpHSwTH1QPuwxHpWslhckUQWbNRM4ho5g==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.20.3",
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-discard-comments": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
+			"integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+			"dev": true,
+			"requires": {}
+		},
+		"postcss-discard-duplicates": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
+			"integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+			"dev": true,
+			"requires": {}
+		},
+		"postcss-discard-empty": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
+			"integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+			"dev": true,
+			"requires": {}
+		},
+		"postcss-discard-overridden": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
+			"integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+			"dev": true,
+			"requires": {}
+		},
+		"postcss-merge-longhand": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.6.tgz",
+			"integrity": "sha512-6C/UGF/3T5OE2CEbOuX7iNO63dnvqhGZeUnKkDeifebY0XqkkvrctYSZurpNE902LDf2yKwwPFgotnfSoPhQiw==",
+			"dev": true,
+			"requires": {
+				"postcss-value-parser": "^4.2.0",
+				"stylehacks": "^5.1.0"
+			}
+		},
+		"postcss-merge-rules": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.2.tgz",
+			"integrity": "sha512-zKMUlnw+zYCWoPN6yhPjtcEdlJaMUZ0WyVcxTAmw3lkkN/NDMRkOkiuctQEoWAOvH7twaxUUdvBWl0d4+hifRQ==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.16.6",
+				"caniuse-api": "^3.0.0",
+				"cssnano-utils": "^3.1.0",
+				"postcss-selector-parser": "^6.0.5"
+			}
+		},
+		"postcss-minify-font-values": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
+			"integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
+			"dev": true,
+			"requires": {
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-minify-gradients": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.1.tgz",
+			"integrity": "sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==",
+			"dev": true,
+			"requires": {
+				"colord": "^2.9.1",
+				"cssnano-utils": "^3.1.0",
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-minify-params": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.3.tgz",
+			"integrity": "sha512-bkzpWcjykkqIujNL+EVEPOlLYi/eZ050oImVtHU7b4lFS82jPnsCb44gvC6pxaNt38Els3jWYDHTjHKf0koTgg==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.16.6",
+				"cssnano-utils": "^3.1.0",
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-minify-selectors": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
+			"integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
+			"dev": true,
+			"requires": {
+				"postcss-selector-parser": "^6.0.5"
+			}
+		},
 		"postcss-modules-extract-imports": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
 			"integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-<<<<<<< HEAD
-			"dev": true
-=======
 			"dev": true,
 			"requires": {}
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"postcss-modules-local-by-default": {
 			"version": "4.0.0",
@@ -10339,6 +11507,116 @@
 				"icss-utils": "^5.0.0"
 			}
 		},
+		"postcss-normalize-charset": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
+			"integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+			"dev": true,
+			"requires": {}
+		},
+		"postcss-normalize-display-values": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
+			"integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
+			"dev": true,
+			"requires": {
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-normalize-positions": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
+			"integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
+			"dev": true,
+			"requires": {
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-normalize-repeat-style": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
+			"integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
+			"dev": true,
+			"requires": {
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-normalize-string": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
+			"integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
+			"dev": true,
+			"requires": {
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-normalize-timing-functions": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
+			"integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
+			"dev": true,
+			"requires": {
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-normalize-unicode": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
+			"integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.16.6",
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-normalize-url": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
+			"integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
+			"dev": true,
+			"requires": {
+				"normalize-url": "^6.0.1",
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-normalize-whitespace": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.1.tgz",
+			"integrity": "sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==",
+			"dev": true,
+			"requires": {
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-ordered-values": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
+			"integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
+			"dev": true,
+			"requires": {
+				"cssnano-utils": "^3.1.0",
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"postcss-reduce-initial": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
+			"integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.16.6",
+				"caniuse-api": "^3.0.0"
+			}
+		},
+		"postcss-reduce-transforms": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
+			"integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
+			"dev": true,
+			"requires": {
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
 		"postcss-selector-parser": {
 			"version": "6.0.10",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
@@ -10347,6 +11625,25 @@
 			"requires": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
+			}
+		},
+		"postcss-svgo": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
+			"integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
+			"dev": true,
+			"requires": {
+				"postcss-value-parser": "^4.2.0",
+				"svgo": "^2.7.0"
+			}
+		},
+		"postcss-unique-selectors": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",
+			"integrity": "sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==",
+			"dev": true,
+			"requires": {
+				"postcss-selector-parser": "^6.0.5"
 			}
 		},
 		"postcss-value-parser": {
@@ -10407,10 +11704,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -10628,12 +11921,7 @@
 		"safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true
-=======
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -10674,10 +11962,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
 			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@types/json-schema": "^7.0.8",
 				"ajv": "^6.12.5",
@@ -10755,10 +12039,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
 			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"randombytes": "^2.1.0"
 			}
@@ -10904,12 +12184,7 @@
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true
-=======
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"source-map-js": {
 			"version": "1.0.2",
@@ -10921,10 +12196,6 @@
 			"version": "0.5.21",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -10956,6 +12227,12 @@
 				"readable-stream": "^3.0.6",
 				"wbuf": "^1.7.3"
 			}
+		},
+		"stable": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+			"dev": true
 		},
 		"statuses": {
 			"version": "2.0.1",
@@ -10999,21 +12276,23 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
 			"integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-<<<<<<< HEAD
-			"dev": true
-=======
 			"dev": true,
 			"requires": {}
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
+		},
+		"stylehacks": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
+			"integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.16.6",
+				"postcss-selector-parser": "^6.0.4"
+			}
 		},
 		"supports-color": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"has-flag": "^4.0.0"
 			}
@@ -11024,24 +12303,38 @@
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
 			"dev": true
 		},
+		"svgo": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+			"integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+			"dev": true,
+			"requires": {
+				"@trysound/sax": "0.2.0",
+				"commander": "^7.2.0",
+				"css-select": "^4.1.3",
+				"css-tree": "^1.1.3",
+				"csso": "^4.2.0",
+				"picocolors": "^1.0.0",
+				"stable": "^0.1.8"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+					"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+					"dev": true
+				}
+			}
+		},
 		"tapable": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-			"dev": true
-=======
 			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"terser": {
 			"version": "5.15.1",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
 			"integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@jridgewell/source-map": "^0.3.2",
 				"acorn": "^8.5.0",
@@ -11053,10 +12346,6 @@
 			"version": "5.3.6",
 			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
 			"integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.14",
 				"jest-worker": "^27.4.5",
@@ -11146,10 +12435,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
 			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"escalade": "^3.1.1",
 				"picocolors": "^1.0.0"
@@ -11197,10 +12482,6 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
 			"integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -11219,10 +12500,6 @@
 			"version": "5.74.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
 			"integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
-<<<<<<< HEAD
-			"dev": true,
-=======
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 			"requires": {
 				"@types/eslint-scope": "^3.7.3",
 				"@types/estree": "^0.0.51",
@@ -11423,12 +12700,7 @@
 		"webpack-sources": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-<<<<<<< HEAD
-			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-			"dev": true
-=======
 			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"websocket-driver": {
 			"version": "0.7.4",
@@ -11472,17 +12744,19 @@
 			"version": "8.9.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
 			"integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
-<<<<<<< HEAD
-			"dev": true
-=======
 			"dev": true,
 			"requires": {}
->>>>>>> f96021bf9b75c47a21a7f831d95746571a0d782f
 		},
 		"yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
+		"yaml": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
 			"dev": true
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "webpack --config webpack.config.js",
 		"dev": "webpack --config webpack.config.dev.js",
-		"start": "webpack server --config webpack.config.dev.js"
+		"start": "webpack serve --config webpack.config.dev.js --open"
 	},
 	"keywords": [],
 	"author": "Diego Delgado Mao <diegomauricio.delgadoe@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
 		"@babel/preset-react": "^7.18.6",
 		"babel-loader": "^8.2.5",
 		"css-loader": "^6.7.1",
+		"css-minimizer-webpack-plugin": "^4.2.2",
 		"html-loader": "^4.2.0",
 		"html-webpack-plugin": "^5.5.0",
 		"sass": "^1.55.0",
 		"sass-loader": "^13.1.0",
 		"style-loader": "^3.3.1",
+		"terser-webpack-plugin": "^5.3.6",
 		"webpack": "^5.74.0",
 		"webpack-cli": "^4.10.0",
 		"webpack-dev-server": "^4.11.1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,10 +5,11 @@ const TerserPlugin = require('terser-webpack-plugin');
 const MinimizerPlugin = require('css-minimizer-webpack-plugin');
 
 module.exports = {
+	mode: 'development',
 	entry: "./src/index.js",
 	output: {
 		path: path.resolve(__dirname, "dist"),
-		filename: "[name].[contenthash].js",
+		filename: "[name].[contenthash].bundle.js",
 	},
 	mode: 'production',
 	resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,14 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MinicssPlugin = require("mini-css-extract-plugin");
+const TerserPlugin = require('terser-webpack-plugin');
+const MinimizerPlugin = require('css-minimizer-webpack-plugin');
 
 module.exports = {
 	entry: "./src/index.js",
 	output: {
 		path: path.resolve(__dirname, "dist"),
-		filename: "bundle.js",
+		filename: "[name].[contenthash].js",
 	},
 	mode: 'production',
 	resolve: {
@@ -45,7 +47,14 @@ module.exports = {
 			filename: "index.html",
 		}),
 		new MinicssPlugin({
-			filename: '[name].css'
+			filename: 'assets/[name].[contenthash].css'
 		}),
 	],
+	optimization: {
+		minimize: true,
+		minimizer: [
+		  new MinimizerPlugin(),
+		  new TerserPlugin(),
+		]
+	  },
 };


### PR DESCRIPTION
Esta bien, aunque actualmente no se si necesario instalar la dependencia de `terser-webpack-plugin` ya que a partir de webpack 5 viene integrada por default. Tocaría hacer comparativas. [webpack tester-plugin]((https://webpack.js.org/plugins/terser-webpack-plugin/))

Para que se abra por default el servidor de desarrollo se podría configurarlo desde el `webpack.config.dev.js` cambiando `devServer.open: true` (esta en false), para dejar el script del `package.json` más limpio 